### PR TITLE
Improve "show current branch status only"

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -55,28 +55,30 @@ export class ApiClient {
 
   public async getRecentBuilds(): Promise<any> {
     try {
-      this.gitBranch = await this.getCurrentBranch();
+      let path = 'project/' + this.vcsType + '/' + this.userName + '/' + this.projectName;
 
-      const path = 'project/' + this.vcsType + '/' + this.userName + '/' + this.projectName;
+      this.gitBranch = await this.getCurrentBranch();
+      if (this.gitBranch !== undefined) {
+        path += '/tree/' + this.gitBranch;
+      }
+
       let recentBuilds: Types.RecentBuild[] = [];
 
       const response = await this.requestApiWithGet(path);
       response.data.forEach((element: any) => {
-        if (this.gitBranch === undefined || element.branch === this.gitBranch) {
-          recentBuilds.push({
-            status: element.status,
-            buildUrl: element.build_url,
-            buildNum: element.build_num,
-            subject: element.subject === null ? '' : element.subject,
-            branch: element.branch,
-            committerName: element.committer_name === null ? '' : element.committer_name,
-            workflowName: element.workflows ? element.workflows.workflow_name : '',
-            jobName: element.workflows ? element.workflows.job_name : '',
-            usageQueuedAt: element.usage_queued_at
-          });
-        }
+        recentBuilds.push({
+          status: element.status,
+          buildUrl: element.build_url,
+          buildNum: element.build_num,
+          subject: element.subject === null ? '' : element.subject,
+          branch: element.branch,
+          committerName: element.committer_name === null ? '' : element.committer_name,
+          workflowName: element.workflows ? element.workflows.workflow_name : '',
+          jobName: element.workflows ? element.workflows.job_name : '',
+          usageQueuedAt: element.usage_queued_at
+        });
       });
-  
+
       return recentBuilds;
     } catch (err) {
       vscode.window.showErrorMessage('Failed to get builds.');


### PR DESCRIPTION
Related to issue #25
Since the current method fetches 30 build information at a time, if the desired branch's build information is behind 30 build information, the result is not known.
Modify to input the desired branch information when calling API.